### PR TITLE
added proper compile feature property propagation

### DIFF
--- a/MathLib/CMakeLists.txt
+++ b/MathLib/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(MathLib INTERFACE)
 target_include_directories(MathLib INTERFACE "Include")
-set_property(TARGET MathLib PROPERTY CXX_STANDARD 20)
+target_compile_features(MathLib INTERFACE cxx_std_20)

--- a/MathLib/CMakeLists.txt
+++ b/MathLib/CMakeLists.txt
@@ -1,3 +1,12 @@
+
 add_library(MathLib INTERFACE)
-target_include_directories(MathLib INTERFACE "Include")
-target_compile_features(MathLib INTERFACE cxx_std_20)
+
+target_include_directories(MathLib
+    INTERFACE
+    "Include"
+)
+
+target_compile_features(MathLib
+    INTERFACE
+    cxx_std_20
+)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -23,8 +23,6 @@ target_sources(Tests PRIVATE
     "TestUtilsContainerTools.cpp"
 )
 
-set_property(TARGET Tests PROPERTY CXX_STANDARD 20)
-
 if(MSVC)
     target_compile_options(Tests PRIVATE /W4)
 else()


### PR DESCRIPTION
Using target_compile_features can ensure that the target that uses the library will also use correct compile features.